### PR TITLE
TBOX 151: Test namespace imports

### DIFF
--- a/tamr_toolbox/__init__.py
+++ b/tamr_toolbox/__init__.py
@@ -16,7 +16,6 @@ __all__ = [
     "data_io",
     "models",
     "filesystem",
-    "models",
     "project",
     "utils",
     "workflow",

--- a/tamr_toolbox/data_io/__init__.py
+++ b/tamr_toolbox/data_io/__init__.py
@@ -3,5 +3,6 @@ from . import dataframe
 from . import df_connect
 from . import csv
 from . import common
+from . import file_system_type
 
-__all__ = ["common", "csv", "dataframe", "df_connect"]
+__all__ = ["common", "csv", "dataframe", "df_connect", "file_system_type"]

--- a/tamr_toolbox/models/__init__.py
+++ b/tamr_toolbox/models/__init__.py
@@ -2,5 +2,6 @@
 from . import project_type
 from . import data_type
 from . import operation_state
+from . import validation_check
 
-__all__ = ["project_type", "data_type", "operation_state"]
+__all__ = ["project_type", "data_type", "operation_state", "validation_check"]

--- a/tests/test__common.py
+++ b/tests/test__common.py
@@ -16,7 +16,6 @@ def test__valid_toolbox_root_dir():
 
 
 def test__import_namespaces():
-
     def check_subpackage_imports(subpackage: ModuleType, directory_path: Path) -> None:
         """Recursively asserts that all files/directories within a directory path are importable
         from the subpackage

--- a/tests/test__common.py
+++ b/tests/test__common.py
@@ -1,8 +1,10 @@
 """Tests for common tasks to the testing framework only"""
+from types import ModuleType
 
 from tests._common import get_toolbox_root_dir
 from pathlib import Path
-
+import os
+import importlib
 
 def test__valid_toolbox_root_dir():
     path = get_toolbox_root_dir()
@@ -10,3 +12,38 @@ def test__valid_toolbox_root_dir():
     assert path.is_absolute()
     # test that we can find this file using the toolbox root directory
     assert path / "tests" / "test__common.py" == Path(__file__)
+
+
+def test__import_namespaces():
+
+    def check_subpackage_imports(subpackage: ModuleType, directory_path: Path) -> None:
+        """Recursively asserts that all files/directories within a directory path are importable
+        from the subpackage
+
+        Args:
+            subpackage: The subpackage to check import from
+            directory_path: The directory to compare with the subpackage imports
+        """
+        print(f"Checking all files/directories within {directory_path} are importable")
+        # Collect names of packages we expect based on filenames in the directory
+        modules_by_files = {
+            f.replace(".py", "") for f in os.listdir(directory_path) if not f.startswith("_")
+        }
+        # Collect names of packages that are importable from the module
+        modules_by_namespace = set(subpackage.__all__)
+
+        # We use subset here to allow for imports that are not in the direct file system folder
+        # such as the project._common files which are imported through specific project types
+        assert modules_by_files.issubset(modules_by_namespace)
+
+        # For any subpackages that are also directories, perform the same check
+        for sub_module_name in modules_by_namespace:
+            sub_module_path = directory_path / sub_module_name
+            if os.path.isdir(sub_module_path):
+                sub_module = importlib.import_module(f'{subpackage.__name__}.{sub_module_name}')
+                check_subpackage_imports(sub_module, sub_module_path)
+
+    import tamr_toolbox
+    toolbox_dir = get_toolbox_root_dir() / "tamr_toolbox"
+
+    check_subpackage_imports(tamr_toolbox, toolbox_dir)

--- a/tests/test__common.py
+++ b/tests/test__common.py
@@ -16,6 +16,7 @@ def test__valid_toolbox_root_dir():
 
 
 def test__import_namespaces():
+
     def check_subpackage_imports(subpackage: ModuleType, directory_path: Path) -> None:
         """Recursively asserts that all files/directories within a directory path are importable
         from the subpackage
@@ -30,14 +31,16 @@ def test__import_namespaces():
             f.replace(".py", "") for f in os.listdir(directory_path) if not f.startswith("_")
         }
         # Collect names of packages that are importable from the module
-        modules_by_namespace = set(subpackage.__all__)
+        modules_by_namespace_all = set(subpackage.__all__)
+        modules_by_namespace_dir = {p for p in subpackage.__dir__() if (not p.startswith("_"))}
 
         # We use subset here to allow for imports that are not in the direct file system folder
         # such as the project._common files which are imported through specific project types
-        assert modules_by_files.issubset(modules_by_namespace)
+        assert modules_by_files.issubset(modules_by_namespace_all)
+        assert modules_by_files.issubset(modules_by_namespace_dir)
 
         # For any subpackages that are also directories, perform the same check
-        for sub_module_name in modules_by_namespace:
+        for sub_module_name in modules_by_namespace_dir:
             sub_module_path = directory_path / sub_module_name
             if os.path.isdir(sub_module_path):
                 sub_module = importlib.import_module(f"{subpackage.__name__}.{sub_module_name}")

--- a/tests/test__common.py
+++ b/tests/test__common.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import os
 import importlib
 
+
 def test__valid_toolbox_root_dir():
     path = get_toolbox_root_dir()
     assert path.exists()
@@ -15,7 +16,6 @@ def test__valid_toolbox_root_dir():
 
 
 def test__import_namespaces():
-
     def check_subpackage_imports(subpackage: ModuleType, directory_path: Path) -> None:
         """Recursively asserts that all files/directories within a directory path are importable
         from the subpackage
@@ -40,10 +40,11 @@ def test__import_namespaces():
         for sub_module_name in modules_by_namespace:
             sub_module_path = directory_path / sub_module_name
             if os.path.isdir(sub_module_path):
-                sub_module = importlib.import_module(f'{subpackage.__name__}.{sub_module_name}')
+                sub_module = importlib.import_module(f"{subpackage.__name__}.{sub_module_name}")
                 check_subpackage_imports(sub_module, sub_module_path)
 
     import tamr_toolbox
+
     toolbox_dir = get_toolbox_root_dir() / "tamr_toolbox"
 
     check_subpackage_imports(tamr_toolbox, toolbox_dir)


### PR DESCRIPTION
# ↪️ Pull Request

* Adds testing for proper namespacing of modules. 
* Fixes some modules that were not previously importable from the namespace

## ✔️ PR Todo

- [ ] Add documentation
- [ ] Add examples
- [ ] Ensure you are following the practices in the [contributor guide](https://docs.google.com/document/d/1c_hhpDMhO0zN793Z_HFOz42Q4g7l1nPRVQ5pXOUsMJU/edit) and [coding_standards](https://datatamr.atlassian.net/wiki/spaces/FEKB/blog/2020/04/14/1137606830/Customer+Success+Coding+Standards)
  * [Use consistent and descriptive name conventions](https://docs.google.com/document/d/1c_hhpDMhO0zN793Z_HFOz42Q4g7l1nPRVQ5pXOUsMJU/edit#heading=h.477s36w4rds9) 
  * [Uses google-style docstrings](https://datatamr.atlassian.net/wiki/spaces/FEKB/blog/2020/04/14/1137606830/Customer+Success+Coding+Standards#Google-style-docstrings)
  * [Uses versioned API/client methods only](https://docs.google.com/document/d/1c_hhpDMhO0zN793Z_HFOz42Q4g7l1nPRVQ5pXOUsMJU/edit#heading=h.yv6df99fyrq2)
  * [Avoid global variables](https://datatamr.atlassian.net/wiki/spaces/FEKB/blog/2020/04/14/1137606830/Customer+Success+Coding+Standards#Avoid-global-variables)
  * [Avoid giant try/catch](https://datatamr.atlassian.net/wiki/spaces/FEKB/blog/2020/04/14/1137606830/Customer+Success+Coding+Standards#Avoid-giant-try-/-except)
  * [Don't use mutable default variables](https://datatamr.atlassian.net/wiki/spaces/FEKB/blog/2020/04/14/1137606830/Customer+Success+Coding+Standards#Don%E2%80%99t-use-mutable-default-arguments)
  * [Use a `main()` function in your scripts](https://datatamr.atlassian.net/wiki/spaces/FEKB/blog/2020/04/14/1137606830/Customer+Success+Coding+Standards#Use-a-%E2%80%9Cmain()%E2%80%9D--function-in-your-scripts)
- [ ] Added/updated testing for this change (ensure you are testing any changes/new code!)
- [ ] Update title to link to TBOX issue (i.e. start pull request title with TBOX-xx) 
- [ ] Approval from first code-reviewer
- [ ] Approval from second code-reviewer (only required if a second reviewer has left comments)
- [ ] Pass all checks
