### PR TITLE
TBOX-174: Fix installation instructions for specifying optional dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # tamr-toolbox
-Tamr-Toolbox is a python library created to provide a simple interface for common interactions with Tamr and common data workflows that include Tamr. The more specialized [Tamr-Client](https://github.com/Datatamer/tamr-client) python library is used for direct interactions with Tamr in both the development of the Tamr-Toolbox and in the recommended use of the Tamr-Toolbox.
+The Tamr Toolbox is a Python library created to provide a simple interface for common interactions with Tamr and common data workflows that include Tamr. The more specialized [Tamr Python Client](https://github.com/Datatamer/tamr-client) library is used for direct interactions with Tamr in both the development of the Tamr Toolbox and in the recommended use of the Tamr Toolbox.
 
 __Releases:__ https://github.com/Datatamer/tamr-toolbox/releases 
 

--- a/doc_src/generate_pdf.py
+++ b/doc_src/generate_pdf.py
@@ -1,4 +1,4 @@
-"""Generate a PDF of the Tamr-Toolbox doc_src
+"""Generate a PDF of the Tamr Toolbox doc_src
 Requires installation of wkhtmltopdf, Mac install command: brew cask install wkhtmltopdf
 """
 from pathlib import Path

--- a/doc_src/index.md
+++ b/doc_src/index.md
@@ -1,11 +1,11 @@
 # Tamr Toolbox
 
-Tamr-Toolbox is a python library created to provide a simple interface for common interactions with Tamr and common data workflows that include Tamr. The more specialized [Tamr-Client](https://github.com/Datatamer/tamr-client) python library is used for direct interactions with Tamr in both the development of the Tamr-Toolbox and in the recommended use of the Tamr-Toolbox.  
+The Tamr Toolbox is a Python library created to provide a simple interface for common interactions with Tamr and common data workflows that include Tamr. The more specialized [Tamr Python Client](https://github.com/Datatamer/tamr-client) library is used for direct interactions with Tamr in both the development of the Tamr Toolbox and in the recommended use of the Tamr Toolbox.  
 
 
 ## Basic Installation
 
-`pip install tamr-toolbox[all]`
+`pip install 'tamr-toolbox[all]'`
  
  [See more installation options](installation.md)
 
@@ -35,7 +35,7 @@ config = utils.config.from_yaml("/home/data/project/conf/project.config.yaml")
 # Make a logger for your script
 logger = utils.logger.create(__name__, log_directory=config["logging_dir"])
 
-# Optionally, configure Tamr-Toolbox to write to the same log file
+# Optionally, configure tamr_toolbox to write to the same log file
 utils.logger.enable_toolbox_logging(log_directory=config["logging_dir"])
 
 # Create a Tamr Client 
@@ -47,7 +47,7 @@ my_projects = [tamr_client.projects.by_resource_id(p_id) for p_id in config["my_
 # Write your own logging message
 logger.info(f"Running projects loaded from config: {[p.name for p in my_projects]}")
 
-# Use the Tamr-Toolbox workflow module to run a list of projects 
+# Use the tamr_toolbox.workflow module to run a list of projects 
 workflow.jobs.run(my_projects)
 
 ```

--- a/doc_src/installation.md
+++ b/doc_src/installation.md
@@ -2,76 +2,76 @@
 
 **Pip Install**
 
-`pip install tamr_toolbox[all]`
+`pip install 'tamr-toolbox[all]'`
   
 
 **Optional Features**
 
-Some features of Tamr-Toolbox require additional dependencies. You can opt-in to these features during installation. By including `tamr_toolbox[all]` in the pip installation command, you will install the dependencies required for all optional features. To include dependencies required for one or more optional features use `tamr_toolbox[feature_1, feature_2]`. A minimal installation is achieved by omitting the `[]` entirely.
+Some features of the Tamr Toolbox require additional dependencies. You can opt-in to these features during installation. By including `'tamr-toolbox[all]'` in the pip installation command, you will install the dependencies required for all optional features. To include dependencies required for one or more optional features use `'tamr-toolbox[feature_1, feature_2]'`. A minimal installation is achieved by omitting the `[]` entirely.
 
 In some cases you may already have a version of the library installed and would prefer to use that instead. Or perhaps
 you would like better control over what version you are installing. 
 If doing so, please use at least minimum version of the library specified below. 
-You will then want to install a version of tamr-toolbox
+You will then want to install a version of `tamr-toolbox`
 without that library included (such as the version with no optional features) so that it does not attempt to change 
 your existing version.
 
 ***All optional features (suggested)***
 
 Install instructions:
-`pip install tamr_toolbox[all]`
+`pip install 'tamr-toolbox[all]'`
 
 ***No optional features***
 
 Install instructions:
-`pip install tamr_toolbox`
+`pip install tamr-toolbox`
 
 ***Optional Feature: Google Translate***
 
 Install instructions:
-`pip install tamr_toolbox[translation]`
+`pip install 'tamr-toolbox[translation]'`
 
 Required for [Translation Enrichment](modules/enrichment/translation.md)
 
-Library: [GoogleTranslate](https://github.com/googleapis/python-translate) (Tamr-toolbox uses version == 2.0.1)
+Library: [GoogleTranslate](https://github.com/googleapis/python-translate) (`tamr-toolbox` uses version == 2.0.1)
 
 Note: You will additionally need your own google API key in order to use translation capabilities.
 
 ***Optional Feature: Mock API Testing***
 
 Install instructions:
-`pip install tamr_toolbox[testing]`
+`pip install 'tamr-toolbox[testing]'`
 
 Required for [Testing](modules/utils)
 
-Library: [Responses](https://github.com/getsentry/responses) (Tamr-Toolbox uses version == 0.10.14)
+Library: [Responses](https://github.com/getsentry/responses) (`tamr-toolbox` uses version == 0.10.14)
 
 ***Optional Feature: Pandas dataframes***
 
 Install instructions:
-`pip install tamr_toolbox[pandas]`
+`pip install 'tamr-toolbox[pandas]'`
 
 Required for [DataFrame I/O](modules/data_io/dataframe.md)
 
-Library: [Pandas](https://pandas.pydata.org/pandas-docs/stable/) (Tamr-Toolbox uses version >= 0.21.0)
+Library: [Pandas](https://pandas.pydata.org/pandas-docs/stable/) (`tamr-toolbox` uses version >= 0.21.0)
 
 ***Optional Feature: Slack Notifications***
 
 Install instructions:
-`pip install tamr_toolbox[slack]`
+`pip install 'tamr-toolbox[slack]'`
 
 Required for [Slack](modules/notifications/slack.md)
 
-Library: [Slack Client](https://github.com/slackapi/python-slackclient) (Tamr-Toolbox uses version >= 2.7.2)
+Library: [Slack Client](https://github.com/slackapi/python-slackclient) (`tamr-toolbox` uses version >= 2.7.2)
 
 
 
 **Offline installation**
 
-Download `tamr_toolbox` and its dependencies on a machine with the same operating system and python version as your target system, that has online access to PyPI:
+Download `tamr-toolbox` and its dependencies on a machine with the same operating system and python version as your target system, that has online access to PyPI:
 
 ```bash
-pip download tamr_toolbox[all] -d tamr-toolbox-requirements
+pip download 'tamr-toolbox[all]' -d tamr-toolbox-requirements
 zip -r tamr-toolbox-requirements.zip tamr-toolbox-requirements
 ```
 
@@ -81,11 +81,11 @@ Finally, install `tamr-toolbox` from the saved dependencies:
 
 ```bash
 unzip tamr-toolbox-requirements.zip
-pip install --no-index --find-links=tamr-toolbox-requirements tamr_toolbox[all]
+pip install --no-index --find-links=tamr-toolbox-requirements 'tamr-toolbox[all]'
 ```
 
 If you are not using a virtual environment, you may need to specify the `--user` flag if you get permissions errors:
 
 ```bash
-pip install --user --no-index --find-links=tamr-toolbox-requirements tamr_toolbox[all]
+pip install --user --no-index --find-links=tamr-toolbox-requirements 'tamr-toolbox[all]'
 ```

--- a/examples/snippets/utils/logger/how_to_log.py
+++ b/examples/snippets/utils/logger/how_to_log.py
@@ -1,4 +1,4 @@
-"""Snippet showing how the logger module of Tamr-Toolbox works"""
+"""Snippet showing how the logger module of tamr_toolbox works"""
 import tamr_toolbox as tbox
 
 # Often I want to log things as my script progresses - to do this you need a logger object

--- a/install.py
+++ b/install.py
@@ -1,4 +1,4 @@
-"""Install requirements for development of the Tamr-Toolbox"""
+"""Install requirements for development of the Tamr Toolbox"""
 from pathlib import Path
 from subprocess import run
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-"""Defines the package Tamr-Toolbox for user installations"""
+"""Defines the package tamr_toolbox for user installations"""
 from setuptools import setup, find_packages
 
 with open("requirements.txt") as f:

--- a/tests/_common.py
+++ b/tests/_common.py
@@ -1,4 +1,4 @@
-"""Tasks for use in the testing of the Tamr-Toolbox"""
+"""Tasks for use in the testing of the Tamr Toolbox"""
 from pathlib import Path
 
 

--- a/tests/examples/__init__.py
+++ b/tests/examples/__init__.py
@@ -1,1 +1,1 @@
-"""Tests for Tamr-Toolbox example scripts"""
+"""Tests for Tamr Toolbox example scripts"""

--- a/tests/examples/project/__init__.py
+++ b/tests/examples/project/__init__.py
@@ -1,1 +1,1 @@
-"""Tests for Tamr-Toolbox example scripts for projects"""
+"""Tests for Tamr Toolbox example scripts for projects"""


### PR DESCRIPTION
# ↪️ Pull Request
This PR fixes an error in the instructions for installing `tamr-toolbox` with optional dependencies, e.g. `tamr-toolbox[all]`.

Also, an effort has been made to enforce uniformity in how the project name appears "Tamr Toolbox", "`tamr-toolbox`" (for the PyPI name), and "`tamr_toolbox`" (for the in-code Python module/package).

## ✔️ PR Todo

- [x] Add documentation
- [x] Update title to link to TBOX issue (i.e. start pull request title with TBOX-xx) 
- [x] Approval from first code-reviewer
- [x] Approval from second code-reviewer (only required if a second reviewer has left comments)
- [x] Pass all checks
