### PR TITLE
TBOX-143: Trigger the Publish to PyPI action when a release is created

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,8 @@
-name: Publish to PyPi
+name: Publish to PyPI
 
 on:
+  release:
+    types: [released]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test_publish.yml
+++ b/.github/workflows/test_publish.yml
@@ -1,10 +1,10 @@
-name: Publish to TestPyPi
+name: Publish to TestPyPI
 
 on:
   workflow_dispatch:
     inputs:
       branch_name:
-        description: 'The name of the branch or tag to publish to TestPyPi'
+        description: 'The name of the branch or tag to publish to TestPyPI'
         required: true
       version_name:
         description: 'Value to use for version name when publishing.  Cannot be the same as any previously used version name.  Consider the current version followed by the date and another number, e.g. 1.1.1.3.4.21.1'


### PR DESCRIPTION
# ↪️ Pull Request

This PR modifies the Publish to PyPI action to be triggered when a release is published.

## ✔️ PR Todo

- [x] Update title to link to TBOX issue (i.e. start pull request title with TBOX-xx) 
- [x] Approval from first code-reviewer
- [ ] Approval from second code-reviewer (only required if a second reviewer has left comments)
- [x] Pass all checks
