### PR TITLE
TBOX-112: Make config immutable in from_yaml method

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 requests>=2.22
 tamr_unify_client>=0.13.0
 PyYAML==5.3.1
-
+pyrsistent==0.17.3

--- a/tamr_toolbox/utils/config.py
+++ b/tamr_toolbox/utils/config.py
@@ -2,13 +2,12 @@
 from typing import Union, Optional
 from pathlib import Path
 
+from pyrsistent import freeze, PMap
 import yaml
 import logging
 import re
 
 import os
-
-from tamr_toolbox.models.data_type import JsonDict
 
 LOGGER = logging.getLogger(__name__)
 
@@ -34,8 +33,9 @@ def _yaml_env_variable_constructor(loader, node):
     return value
 
 
-def _yaml_env_loader(path_to_file: Optional[Union[str, Path]]) -> JsonDict:
-    """Reads a yaml file and creates a dictionary, retrieving environment variables as needed
+def _yaml_env_loader(path_to_file: Optional[Union[str, Path]]) -> PMap:
+    """Reads a yaml file and creates an immutable pyrsistent PMap (dictionary),
+    retrieving environment variables as needed
 
     Args:
         path_to_file: Path to config yaml file
@@ -51,16 +51,16 @@ def _yaml_env_loader(path_to_file: Optional[Union[str, Path]]) -> JsonDict:
     with open(path_to_file, "r") as config_file:
         configs = yaml.load(config_file.read(), Loader=yaml_loader)
     LOGGER.info(f"Configurations have been loaded from {path_to_file}")
-    return configs
+    return freeze(configs)
 
 
 def from_yaml(
     path_to_file: Optional[Union[str, Path]],
     *,
     default_path_to_file: Optional[Union[str, Path]] = None,
-) -> JsonDict:
-    """Reads a yaml file and creates a dictionary. Input values can be retrieved from environment
-    variables
+) -> PMap:
+    """Reads a yaml file and creates an immutable pyrsistent PMap (dictionary).
+    Input values can be retrieved from environment variables
 
     Args:
         path_to_file: Path to config yaml file

--- a/tests/utils/test_config.py
+++ b/tests/utils/test_config.py
@@ -81,3 +81,30 @@ def test_from_yaml_with_path():
         ),
     )
     assert my_config_2["my_other_instance"]["host"] == "1.2.3.4"
+
+
+def test_config_immutable():
+    # set needed environment variables and ensure we read them in correctly
+    os.environ["TAMR_MY_INSTANCE_HOST"] = "localhost"
+    os.environ["TAMR_MY_INSTANCE_USERNAME"] = "user"
+    os.environ["TAMR_MY_INSTANCE_PASSWORD"] = "password"
+
+    my_config = tamr_toolbox.utils.config.from_yaml(
+        get_toolbox_root_dir() / "tests/mocking/resources/environment_variables.config.yaml"
+    )
+    assert my_config["my_instance_name"]["host"] == "localhost"
+    assert my_config["my_instance_name"]["username"] == "user"
+    assert my_config["my_instance_name"]["password"] == "password"
+
+    # delete or reassignment raises TypeError
+    # top-level dict
+    with pytest.raises(TypeError):
+        my_config["my_instance_name"] = {}
+    with pytest.raises(TypeError):
+        del my_config["my_instance_name"]
+
+    # top-level dict
+    with pytest.raises(TypeError):
+        my_config["my_instance_name"]["host"] = "newhost"
+    with pytest.raises(TypeError):
+        del my_config["my_instance_name"]["host"]


### PR DESCRIPTION
# ↪️ Pull Request

This PR changes the functions in `tamr_toolbox.utils.config` to return an immutable `PMap` instead of a standard (mutable) Python dictionary.  Internal data structures (like contained dictionaries) are made immutable recursively.

It adds a new requirement, `pyrsistent`.  This may be the main reason not to accept this PR.

## ✔️ PR Todo

- [x] Add documentation
- [ ] Add examples
- [x] Ensure you are following the practices in the [contributor guide](https://docs.google.com/document/d/1c_hhpDMhO0zN793Z_HFOz42Q4g7l1nPRVQ5pXOUsMJU/edit) and [coding_standards](https://datatamr.atlassian.net/wiki/spaces/FEKB/blog/2020/04/14/1137606830/Customer+Success+Coding+Standards)
  * [Use consistent and descriptive name conventions](https://docs.google.com/document/d/1c_hhpDMhO0zN793Z_HFOz42Q4g7l1nPRVQ5pXOUsMJU/edit#heading=h.477s36w4rds9) 
  * [Uses google-style docstrings](https://datatamr.atlassian.net/wiki/spaces/FEKB/blog/2020/04/14/1137606830/Customer+Success+Coding+Standards#Google-style-docstrings)
  * [Uses versioned API/client methods only](https://docs.google.com/document/d/1c_hhpDMhO0zN793Z_HFOz42Q4g7l1nPRVQ5pXOUsMJU/edit#heading=h.yv6df99fyrq2)
  * [Avoid global variables](https://datatamr.atlassian.net/wiki/spaces/FEKB/blog/2020/04/14/1137606830/Customer+Success+Coding+Standards#Avoid-global-variables)
  * [Avoid giant try/catch](https://datatamr.atlassian.net/wiki/spaces/FEKB/blog/2020/04/14/1137606830/Customer+Success+Coding+Standards#Avoid-giant-try-/-except)
  * [Don't use mutable default variables](https://datatamr.atlassian.net/wiki/spaces/FEKB/blog/2020/04/14/1137606830/Customer+Success+Coding+Standards#Don%E2%80%99t-use-mutable-default-arguments)
  * [Use a `main()` function in your scripts](https://datatamr.atlassian.net/wiki/spaces/FEKB/blog/2020/04/14/1137606830/Customer+Success+Coding+Standards#Use-a-%E2%80%9Cmain()%E2%80%9D--function-in-your-scripts)
- [x] Added/updated testing for this change (ensure you are testing any changes/new code!)
- [x] Update title to link to TBOX issue (i.e. start pull request title with TBOX-xx) 
- [ ] Approval from first code-reviewer
- [ ] Approval from second code-reviewer (only required if a second reviewer has left comments)
- [x] Pass all checks
