### PR TITLE
TBOX-131: logging format

### DIFF
--- a/examples/snippets/utils/logger/how_to_log.py
+++ b/examples/snippets/utils/logger/how_to_log.py
@@ -3,10 +3,10 @@ import tamr_toolbox as tbox
 
 # Often I want to log things as my script progresses - to do this you need a logger object
 # Tamr-toolbox will help you put all of your logs in the same place by giving you simple methods
-# for creating and managing both your custom loggers, logging from the toolbox modules themselves,
-# and loggers from any python library that follow best practices. By default Tamr-toolbox logging
-# will stream all log messages to console, but it is easy enough to have them all go to a file
-# like so.
+# for creating and managing both your custom loggers, logging from your custom modules, logging
+# from the toolbox modules themselves, and loggers from any python libraries that follow best
+# practices. By default Tamr-toolbox logging will stream all log messages to console, but it is
+# easy enough to have them all go to a file like so.
 log = tbox.utils.logger.create("my_log", log_directory=".")
 
 # By default, the logger will still log to the console when a directory is specified, but
@@ -23,8 +23,9 @@ log.info("an info message")
 # written to the same log file by simply calling
 tbox.utils.logger.enable_toolbox_logging(log_directory=".")
 
-# you can extend to any module/library you use in your code via the helpful enable_package_
-# logging method. for example with the tamr unify client
+# you can extend to any module/library you use in your code, including any custom modules in the
+# same codebase as your script, via the helpful enable_package_logging method
+# for example with the tamr unify client
 tbox.utils.logger.enable_package_logging("tamr_unify_client")
 
 # if you need debug for any of your logs that is easy enough, just use the set_logging_level

--- a/tamr_toolbox/utils/logger.py
+++ b/tamr_toolbox/utils/logger.py
@@ -31,9 +31,9 @@ def _add_handler(logger: logging.Logger, log_directory: Optional[str] = None, **
     """Adds a handler to a logger, either a logging.StreamHandler if log_directory is None
     otherwise a logging.FileHandler piped to the directory specified.
 
-     Args:
-         logger: the logging.Logger class to which you would like to add a handler
-         log_directory: Optional log directory to pass. If not None a FileHandler is added,
+    Args:
+        logger: the logging.Logger class to which you would like to add a handler
+        log_directory: Optional log directory to pass. If not None a FileHandler is added,
             otherwise a StreamHandler
          **kwargs: Keyword arguments for the _get_log_filename
      """
@@ -49,7 +49,7 @@ def _add_handler(logger: logging.Logger, log_directory: Optional[str] = None, **
     logger.setLevel(logging.INFO)
     handler.setLevel(logging.INFO)
     formatter = logging.Formatter(
-        "%(levelname)s <%(thread)d> [%(asctime)s] <%(name)s:%(lineno)d>  %(message)s"
+        "%(levelname)s <%(thread)d> [%(asctime)s] %(name)s <%(filename)s:%(lineno)d>  %(message)s"
     )
     handler.setFormatter(formatter)
     logger.addHandler(handler)

--- a/tamr_toolbox/utils/logger.py
+++ b/tamr_toolbox/utils/logger.py
@@ -67,6 +67,12 @@ def create(
     Log file will be located under log_directory with file name
     <log_prefix>_<date>.log, quashing extra separating underscores. Defaults to <date>.log.
 
+    For use in scripts only. To log in module files, use the standard library `logging` module with
+    a module-level logger and enable package logging.  See
+    https://docs.python.org/3/howto/logging.html#advanced-logging-tutorial
+
+    >>> log = logging.getLogger(__name__)
+
     Args:
         name: This sets the name of your logger instance. It does not affect the file name.
             To change the filename use log_prefix


### PR DESCRIPTION
# ↪️ Pull Request

This PR changes the logger format to include both the name of the logger and the name of the file where the logging is called.  Previously only the name of the logger was shown.  The logger name is valuable particularly for external packages with logging enabled, since this indicates the module where the logging call was made.  For custom logging statements, however, the name of the logger is chosen by the script writer, so including the filename is important in this case.

Example:
Run a script called `script.py` with the following contents:
```python
# logger created with name "my_logger"
log = tbox.utils.logger.create("my_logger", log_directory=".")

log.info("an info message")  # direct logging call

tbox.utils.logger.enable_package_logging("tamr_unify_client")
tamr = Client(...)
tamr.request("GET", "service/version")  # tamr_unify_client method that creates a log
```

The resulting logs will be:
```
INFO <4717485504> [2021-06-10 15:31:08,315] my_logger <script.py:10>  an info message
INFO <4717485504> [2021-06-10 15:31:08,418] tamr_unify_client.client <client.py:95>  GET http://10.20.0.139:9100/api/versioned/v1/service/version : 404
```


## ✔️ PR Todo

- [x] Add documentation
- [ ] Add examples
- [x] Ensure you are following the practices in the [contributor guide](https://docs.google.com/document/d/1c_hhpDMhO0zN793Z_HFOz42Q4g7l1nPRVQ5pXOUsMJU/edit) and [coding_standards](https://datatamr.atlassian.net/wiki/spaces/FEKB/blog/2020/04/14/1137606830/Customer+Success+Coding+Standards)
  * [Use consistent and descriptive name conventions](https://docs.google.com/document/d/1c_hhpDMhO0zN793Z_HFOz42Q4g7l1nPRVQ5pXOUsMJU/edit#heading=h.477s36w4rds9) 
  * [Uses google-style docstrings](https://datatamr.atlassian.net/wiki/spaces/FEKB/blog/2020/04/14/1137606830/Customer+Success+Coding+Standards#Google-style-docstrings)
  * [Uses versioned API/client methods only](https://docs.google.com/document/d/1c_hhpDMhO0zN793Z_HFOz42Q4g7l1nPRVQ5pXOUsMJU/edit#heading=h.yv6df99fyrq2)
  * [Avoid global variables](https://datatamr.atlassian.net/wiki/spaces/FEKB/blog/2020/04/14/1137606830/Customer+Success+Coding+Standards#Avoid-global-variables)
  * [Avoid giant try/catch](https://datatamr.atlassian.net/wiki/spaces/FEKB/blog/2020/04/14/1137606830/Customer+Success+Coding+Standards#Avoid-giant-try-/-except)
  * [Don't use mutable default variables](https://datatamr.atlassian.net/wiki/spaces/FEKB/blog/2020/04/14/1137606830/Customer+Success+Coding+Standards#Don%E2%80%99t-use-mutable-default-arguments)
  * [Use a `main()` function in your scripts](https://datatamr.atlassian.net/wiki/spaces/FEKB/blog/2020/04/14/1137606830/Customer+Success+Coding+Standards#Use-a-%E2%80%9Cmain()%E2%80%9D--function-in-your-scripts)
- [ ] Added/updated testing for this change (ensure you are testing any changes/new code!)
- [x] Update title to link to TBOX issue (i.e. start pull request title with TBOX-xx) 
- [x] Approval from first code-reviewer
- [ ] Approval from second code-reviewer (only required if a second reviewer has left comments)
- [x] Pass all checks
