### PR TITLE
TBOX-158: add log_to_terminal flag to enable_package_logging and enable_toolbox_logging

### DIFF
--- a/tamr_toolbox/utils/logger.py
+++ b/tamr_toolbox/utils/logger.py
@@ -35,7 +35,7 @@ def _add_handler(logger: logging.Logger, log_directory: Optional[str] = None, **
         logger: the logging.Logger class to which you would like to add a handler
         log_directory: Optional log directory to pass. If not None a FileHandler is added,
             otherwise a StreamHandler
-         **kwargs: Keyword arguments for the _get_log_filename
+        **kwargs: Keyword arguments for the _get_log_filename
      """
     if log_directory is None:
         handler = logging.StreamHandler()
@@ -49,7 +49,7 @@ def _add_handler(logger: logging.Logger, log_directory: Optional[str] = None, **
     logger.setLevel(logging.INFO)
     handler.setLevel(logging.INFO)
     formatter = logging.Formatter(
-        "%(levelname)s <%(thread)d> [%(asctime)s] %(name)s <%(filename)s:%(lineno)d>  %(message)s"
+        "%(levelname)s <%(thread)d> [%(asctime)s] %(name)s <%(filename)s:%(lineno)d> %(message)s"
     )
     handler.setFormatter(formatter)
     logger.addHandler(handler)
@@ -123,6 +123,7 @@ def set_logging_level(logger_name: str, level: str) -> None:
 def enable_package_logging(
     package_name: str,
     *,
+    log_to_terminal: bool = True,
     log_directory: Optional[str] = None,
     level: Optional[str] = None,
     log_prefix: str = "",
@@ -133,6 +134,7 @@ def enable_package_logging(
 
     Args:
         package_name: the name of the package for which to enable logging
+        log_to_terminal: Boolean indicating whether or not to log messages to the terminal
         log_directory: optional log directory which the package will write logs
         level: optional level to specify, default is WARNING (inherited from base logging package)
         log_prefix: Optional prefix for log files, if None will be blank string
@@ -141,6 +143,8 @@ def enable_package_logging(
 
     package_logger = logging.getLogger(package_name)
     _add_handler(package_logger, log_directory, log_prefix=log_prefix, date_format=date_format)
+    if log_to_terminal:
+        _add_handler(package_logger, log_prefix=log_prefix, date_format=date_format)
 
     if level is not None:
         set_logging_level(package_name, level)
@@ -148,6 +152,7 @@ def enable_package_logging(
 
 def enable_toolbox_logging(
     *,
+    log_to_terminal: bool = True,
     log_directory: Optional[str] = None,
     level: Optional[str] = None,
     log_prefix: str = "",
@@ -156,6 +161,7 @@ def enable_toolbox_logging(
     """A simple wrapper to enable_package_logging to give friendly call for users.
 
     Args:
+        log_to_terminal: Boolean indicating whether or not to log messages to the terminal
         log_directory: optional directory to which to write tamr_toolbox logs
         level: Optional logging level to specify, default is WARNING
             (inherited from base logging package)
@@ -165,6 +171,7 @@ def enable_toolbox_logging(
 
     enable_package_logging(
         "tamr_toolbox",
+        log_to_terminal=log_to_terminal,
         log_directory=log_directory,
         level=level,
         log_prefix=log_prefix,

--- a/tests/utils/test_logger.py
+++ b/tests/utils/test_logger.py
@@ -7,7 +7,6 @@ import tempfile
 import os
 
 import tamr_toolbox.utils.logger
-import importlib
 
 
 def test_logger_name():
@@ -133,11 +132,6 @@ def test_enable_toolbox_logging_with_stream_and_file_handler():
 
 
 def test_enable_toolbox_logging_with_only_file_handler():
-    tamr_toolbox.utils.logger.create(
-        "test_toolbox_logging_stream_and_file",
-        log_to_terminal=True,
-        log_directory=tempfile.gettempdir(),
-    )
     package_logger = logging.getLogger("tamr_toolbox")
     # Reset package logger to have no handlers
     package_logger.handlers.clear()

--- a/tests/utils/test_logger.py
+++ b/tests/utils/test_logger.py
@@ -7,6 +7,7 @@ import tempfile
 import os
 
 import tamr_toolbox.utils.logger
+import importlib
 
 
 def test_logger_name():
@@ -113,12 +114,8 @@ logger = tamr_toolbox.utils.logger.create(
 
 
 def test_enable_toolbox_logging_with_stream_and_file_handler():
-    tamr_toolbox.utils.logger.create(
-        "test_toolbox_logging_stream_and_file",
-        log_to_terminal=True,
-        log_directory=tempfile.gettempdir(),
-    )
     package_logger = logging.getLogger("tamr_toolbox")
+    # Reset package logger to have no handlers
     package_logger.handlers.clear()
     tamr_toolbox.utils.logger.enable_toolbox_logging(
         log_to_terminal=True, log_directory=tempfile.gettempdir()
@@ -142,6 +139,7 @@ def test_enable_toolbox_logging_with_only_file_handler():
         log_directory=tempfile.gettempdir(),
     )
     package_logger = logging.getLogger("tamr_toolbox")
+    # Reset package logger to have no handlers
     package_logger.handlers.clear()
     tamr_toolbox.utils.logger.enable_toolbox_logging(
         log_to_terminal=False, log_directory=tempfile.gettempdir()

--- a/tests/utils/test_logger.py
+++ b/tests/utils/test_logger.py
@@ -110,3 +110,49 @@ logger = tamr_toolbox.utils.logger.create(
     os.system(f"python {script_path}")
 
     assert "ZeroDivisionError" in open(log_file_path).read()
+
+
+def test_enable_toolbox_logging_with_stream_and_file_handler():
+    tamr_toolbox.utils.logger.create(
+        "test_toolbox_logging_stream_and_file",
+        log_to_terminal=True,
+        log_directory=tempfile.gettempdir(),
+    )
+    package_logger = logging.getLogger("tamr_toolbox")
+    package_logger.handlers.clear()
+    tamr_toolbox.utils.logger.enable_toolbox_logging(
+        log_to_terminal=True, log_directory=tempfile.gettempdir()
+    )
+
+    assert len(package_logger.handlers) == 2
+
+    found_file_handler = False
+    found_stream_handler = False
+    for handler in package_logger.handlers:
+        found_file_handler = found_file_handler or type(handler) == logging.FileHandler
+        found_stream_handler = found_stream_handler or type(handler) == logging.StreamHandler
+
+    assert found_file_handler and found_stream_handler
+
+
+def test_enable_toolbox_logging_with_only_file_handler():
+    tamr_toolbox.utils.logger.create(
+        "test_toolbox_logging_stream_and_file",
+        log_to_terminal=True,
+        log_directory=tempfile.gettempdir(),
+    )
+    package_logger = logging.getLogger("tamr_toolbox")
+    package_logger.handlers.clear()
+    tamr_toolbox.utils.logger.enable_toolbox_logging(
+        log_to_terminal=False, log_directory=tempfile.gettempdir()
+    )
+
+    assert len(package_logger.handlers) == 1
+
+    found_file_handler = False
+    found_stream_handler = False
+    for handler in package_logger.handlers:
+        found_file_handler = found_file_handler or type(handler) == logging.FileHandler
+        found_stream_handler = found_stream_handler or type(handler) == logging.StreamHandler
+
+    assert found_file_handler and not found_stream_handler


### PR DESCRIPTION
# ↪️ Pull Request
This PR adds the option to stream logs to the terminal when enabling toolbox logging for imported packages.  By default, the flag is turned on.  This has been passed through to the `enable_toolbox_logging` convenience function.


## ✔️ PR Todo

- [x] Add documentation
- [ ] Add examples
- [x] Ensure you are following the practices in the [contributor guide](https://docs.google.com/document/d/1c_hhpDMhO0zN793Z_HFOz42Q4g7l1nPRVQ5pXOUsMJU/edit) and [coding_standards](https://datatamr.atlassian.net/wiki/spaces/FEKB/blog/2020/04/14/1137606830/Customer+Success+Coding+Standards)
  * [Use consistent and descriptive name conventions](https://docs.google.com/document/d/1c_hhpDMhO0zN793Z_HFOz42Q4g7l1nPRVQ5pXOUsMJU/edit#heading=h.477s36w4rds9) 
  * [Uses google-style docstrings](https://datatamr.atlassian.net/wiki/spaces/FEKB/blog/2020/04/14/1137606830/Customer+Success+Coding+Standards#Google-style-docstrings)
  * [Uses versioned API/client methods only](https://docs.google.com/document/d/1c_hhpDMhO0zN793Z_HFOz42Q4g7l1nPRVQ5pXOUsMJU/edit#heading=h.yv6df99fyrq2)
  * [Avoid global variables](https://datatamr.atlassian.net/wiki/spaces/FEKB/blog/2020/04/14/1137606830/Customer+Success+Coding+Standards#Avoid-global-variables)
  * [Avoid giant try/catch](https://datatamr.atlassian.net/wiki/spaces/FEKB/blog/2020/04/14/1137606830/Customer+Success+Coding+Standards#Avoid-giant-try-/-except)
  * [Don't use mutable default variables](https://datatamr.atlassian.net/wiki/spaces/FEKB/blog/2020/04/14/1137606830/Customer+Success+Coding+Standards#Don%E2%80%99t-use-mutable-default-arguments)
  * [Use a `main()` function in your scripts](https://datatamr.atlassian.net/wiki/spaces/FEKB/blog/2020/04/14/1137606830/Customer+Success+Coding+Standards#Use-a-%E2%80%9Cmain()%E2%80%9D--function-in-your-scripts)
- [x] Added/updated testing for this change (ensure you are testing any changes/new code!)
- [x] Update title to link to TBOX issue (i.e. start pull request title with TBOX-xx) 
- [ ] Approval from first code-reviewer
- [ ] Approval from second code-reviewer (only required if a second reviewer has left comments)
- [ ] Pass all checks
