### PR TITLE
TBOX-186 Update exception caught to be requests.exception.ConnetionError

### DIFF
--- a/tamr_toolbox/utils/client.py
+++ b/tamr_toolbox/utils/client.py
@@ -98,7 +98,7 @@ def get_with_connection_retry(
         try:
             response = client.get(api_endpoint)
             return response
-        except ConnectionError as e:
+        except requests.exceptions.ConnectionError as e:
             # If we got for example a connection refused exception, try again later
             LOGGER.warning(f"Caught exception in connect {e}")
             sleep(sleep_seconds)

--- a/tests/utils/test_client.py
+++ b/tests/utils/test_client.py
@@ -59,26 +59,28 @@ def test_client_enforce_healthy():
 
 @mock_api()
 def test_get_with_connection_retry():
-    # To ensure timeout error is raised to test correct ConnectionError is caught
+
+    tempdir = tempfile.TemporaryDirectory()
 
     log_prefix = "caught_connection_error"
+    log_file_path = os.path.join(tempdir.name, f"{log_prefix}_{utils.logger._get_log_filename()}")
 
-    with tempfile.TemporaryDirectory() as tempdir:
-        log_file_path = os.path.join(tempdir, f"{log_prefix}_{utils.logger._get_log_filename()}")
 
-        if os.path.exists(log_file_path):
-            os.remove(log_file_path)
+    my_client = utils.client.create(**CONFIG["my_other_instance"])
+    utils.logger.enable_toolbox_logging(
+        log_to_terminal=False, log_directory=tempdir.name, log_prefix=log_prefix
+    )
 
-        my_client = utils.client.create(**CONFIG["my_other_instance"])
-        utils.logger.enable_toolbox_logging(
-            log_to_terminal=False, log_directory=tempdir, log_prefix=log_prefix
+    with pytest.raises(TimeoutError):
+        utils.client.get_with_connection_retry(
+            my_client, "/api/service/health", timeout_seconds=10, sleep_seconds=1
         )
 
-        with pytest.raises(TimeoutError):
-            utils.client.get_with_connection_retry(
-                my_client, "/api/service/health", timeout_seconds=10, sleep_seconds=1
-            )
+    with open(log_file_path, "r") as f:
+        # confirm that the intended warning was written to the log
+        assert "Caught exception in connect" in f.read()
 
-        with open(log_file_path, "r") as f:
-            # confirm that the intended warning was written to the log
-            assert "Caught exception in connect" in f.read()
+    try:
+        tempdir.cleanup()
+    except (PermissionError, NotADirectoryError):
+        tempdir.cleanup()

--- a/tests/utils/test_client.py
+++ b/tests/utils/test_client.py
@@ -1,6 +1,7 @@
 """Tests for tasks related to connecting to a Tamr instance"""
 import os
 import pytest
+import tempfile
 from tamr_toolbox import utils
 from tamr_unify_client.auth import UsernamePasswordAuth
 from tamr_toolbox.utils.testing import mock_api
@@ -24,7 +25,9 @@ def test_client_create():
     assert my_client.port == int(CONFIG["my_instance_name"]["port"])
     assert my_client.protocol == CONFIG["my_instance_name"]["protocol"]
     assert my_client.base_path == "/api/versioned/v1/"
-    assert my_client.auth == UsernamePasswordAuth("admin", os.environ["TAMR_TOOLBOX_PASSWORD"],)
+    assert my_client.auth == UsernamePasswordAuth(
+        "admin", os.environ["TAMR_TOOLBOX_PASSWORD"],
+    )
 
 
 @mock_api()
@@ -41,7 +44,9 @@ def test_invalid_credentials():
 
 @mock_api()
 def test_store_auth_cookie():
-    my_client = utils.client.create(**CONFIG["my_instance_name"], store_auth_cookie=True)
+    my_client = utils.client.create(
+        **CONFIG["my_instance_name"], store_auth_cookie=True
+    )
     assert "authToken" in my_client.session.cookies.keys()
     assert my_client.session.auth is None
 
@@ -53,14 +58,33 @@ def test_client_enforce_healthy():
     assert my_client.port == int(CONFIG["my_instance_name"]["port"])
     assert my_client.protocol == CONFIG["my_instance_name"]["protocol"]
     assert my_client.base_path == "/api/versioned/v1/"
-    assert my_client.auth == UsernamePasswordAuth("admin", os.environ["TAMR_TOOLBOX_PASSWORD"],)
+    assert my_client.auth == UsernamePasswordAuth(
+        "admin", os.environ["TAMR_TOOLBOX_PASSWORD"],
+    )
 
 
 @mock_api()
 def test_get_with_connection_retry():
     # To ensure timeout error is raised to test correct ConnectionError is caught
+
+    log_prefix = "caught_connection_error"
+    log_file_path = os.path.join(
+        tempfile.gettempdir(), f"{log_prefix}_{utils.logger._get_log_filename()}"
+    )
+    log_file_path_extended = os.path.join(
+        log_file_path, utils.logger._get_log_filename()
+    )  # because gettempdir creates a directory
+    if os.path.exists(log_file_path_extended):
+        os.remove(log_file_path_extended)
+
     my_client = utils.client.create(**CONFIG["my_other_instance"])
+    utils.logger.enable_toolbox_logging(
+        log_to_terminal=False, log_directory=log_file_path
+    )
+
     with pytest.raises(TimeoutError):
         utils.client.get_with_connection_retry(
             my_client, "/api/service/health", timeout_seconds=10, sleep_seconds=1
         )
+
+    assert "ConnectionError" not in open(log_file_path_extended).read()

--- a/tests/utils/test_client.py
+++ b/tests/utils/test_client.py
@@ -25,9 +25,7 @@ def test_client_create():
     assert my_client.port == int(CONFIG["my_instance_name"]["port"])
     assert my_client.protocol == CONFIG["my_instance_name"]["protocol"]
     assert my_client.base_path == "/api/versioned/v1/"
-    assert my_client.auth == UsernamePasswordAuth(
-        "admin", os.environ["TAMR_TOOLBOX_PASSWORD"],
-    )
+    assert my_client.auth == UsernamePasswordAuth("admin", os.environ["TAMR_TOOLBOX_PASSWORD"],)
 
 
 @mock_api()
@@ -44,9 +42,7 @@ def test_invalid_credentials():
 
 @mock_api()
 def test_store_auth_cookie():
-    my_client = utils.client.create(
-        **CONFIG["my_instance_name"], store_auth_cookie=True
-    )
+    my_client = utils.client.create(**CONFIG["my_instance_name"], store_auth_cookie=True)
     assert "authToken" in my_client.session.cookies.keys()
     assert my_client.session.auth is None
 
@@ -58,9 +54,7 @@ def test_client_enforce_healthy():
     assert my_client.port == int(CONFIG["my_instance_name"]["port"])
     assert my_client.protocol == CONFIG["my_instance_name"]["protocol"]
     assert my_client.base_path == "/api/versioned/v1/"
-    assert my_client.auth == UsernamePasswordAuth(
-        "admin", os.environ["TAMR_TOOLBOX_PASSWORD"],
-    )
+    assert my_client.auth == UsernamePasswordAuth("admin", os.environ["TAMR_TOOLBOX_PASSWORD"],)
 
 
 @mock_api()
@@ -70,9 +64,7 @@ def test_get_with_connection_retry():
     log_prefix = "caught_connection_error"
 
     with tempfile.TemporaryDirectory() as tempdir:
-        log_file_path = os.path.join(
-            tempdir, f"{log_prefix}_{utils.logger._get_log_filename()}"
-        )
+        log_file_path = os.path.join(tempdir, f"{log_prefix}_{utils.logger._get_log_filename()}")
 
         my_client = utils.client.create(**CONFIG["my_other_instance"])
         utils.logger.enable_toolbox_logging(

--- a/tests/utils/test_client.py
+++ b/tests/utils/test_client.py
@@ -65,7 +65,6 @@ def test_get_with_connection_retry():
     log_prefix = "caught_connection_error"
     log_file_path = os.path.join(tempdir.name, f"{log_prefix}_{utils.logger._get_log_filename()}")
 
-
     my_client = utils.client.create(**CONFIG["my_other_instance"])
     utils.logger.enable_toolbox_logging(
         log_to_terminal=False, log_directory=tempdir.name, log_prefix=log_prefix

--- a/tests/utils/test_client.py
+++ b/tests/utils/test_client.py
@@ -74,22 +74,16 @@ def test_get_with_connection_retry():
             tempdir, f"{log_prefix}_{utils.logger._get_log_filename()}"
         )
 
-    # clears old dir
-    if os.path.exists(log_file_path):
-        os.remove(log_file_path)
-    if os.path.exists(log_file_path):
-        os.remove(log_file_path)
-
-    my_client = utils.client.create(**CONFIG["my_other_instance"])
-    utils.logger.enable_toolbox_logging(
-        log_to_terminal=False, log_directory=log_file_path
-    )
-
-    with pytest.raises(TimeoutError):
-        utils.client.get_with_connection_retry(
-            my_client, "/api/service/health", timeout_seconds=10, sleep_seconds=1
+        my_client = utils.client.create(**CONFIG["my_other_instance"])
+        utils.logger.enable_toolbox_logging(
+            log_to_terminal=False, log_directory=tempdir, log_prefix=log_prefix
         )
 
-    with open(log_file_path, "r") as f:
-        # confirm that the intended warning was written to the log
-        assert "Caught exception in connect" in f.read()
+        with pytest.raises(TimeoutError):
+            utils.client.get_with_connection_retry(
+                my_client, "/api/service/health", timeout_seconds=10, sleep_seconds=1
+            )
+
+        with open(log_file_path, "r") as f:
+            # confirm that the intended warning was written to the log
+            assert "Caught exception in connect" in f.read()

--- a/tests/utils/test_client.py
+++ b/tests/utils/test_client.py
@@ -59,7 +59,7 @@ def test_client_enforce_healthy():
 
 @mock_api()
 def test_get_with_connection_retry():
-
+    # Create temp directory. Remember to cleanup!
     tempdir = tempfile.TemporaryDirectory()
 
     log_prefix = "caught_connection_error"
@@ -79,7 +79,9 @@ def test_get_with_connection_retry():
         # confirm that the intended warning was written to the log
         assert "Caught exception in connect" in f.read()
 
+    # Cleanup temp directory
     try:
         tempdir.cleanup()
     except (PermissionError, NotADirectoryError):
+        # Windows sometimes fails so try one more time
         tempdir.cleanup()

--- a/tests/utils/test_client.py
+++ b/tests/utils/test_client.py
@@ -74,20 +74,16 @@ def test_get_with_connection_retry():
             tempdir, f"{log_prefix}_{utils.logger._get_log_filename()}"
         )
 
-    # clears old dir
-    if os.path.exists(log_file_path):
-        os.remove(log_file_path)
-
-    my_client = utils.client.create(**CONFIG["my_other_instance"])
-    utils.logger.enable_toolbox_logging(
-        log_to_terminal=False, log_directory=tempdir, log_prefix=log_prefix
-    )
-
-    with pytest.raises(TimeoutError):
-        utils.client.get_with_connection_retry(
-            my_client, "/api/service/health", timeout_seconds=10, sleep_seconds=1
+        my_client = utils.client.create(**CONFIG["my_other_instance"])
+        utils.logger.enable_toolbox_logging(
+            log_to_terminal=False, log_directory=tempdir, log_prefix=log_prefix
         )
 
-    with open(log_file_path, "r") as f:
-        # confirm that the intended warning was written to the log
-        assert "Caught exception in connect" in f.read()
+        with pytest.raises(TimeoutError):
+            utils.client.get_with_connection_retry(
+                my_client, "/api/service/health", timeout_seconds=10, sleep_seconds=1
+            )
+
+        with open(log_file_path, "r") as f:
+            # confirm that the intended warning was written to the log
+            assert "Caught exception in connect" in f.read()

--- a/tests/utils/test_client.py
+++ b/tests/utils/test_client.py
@@ -68,20 +68,17 @@ def test_get_with_connection_retry():
     # To ensure timeout error is raised to test correct ConnectionError is caught
 
     log_prefix = "caught_connection_error"
-    # creates temporary file directory & fetches file inside dir
+
     with tempfile.TemporaryDirectory() as tempdir:
         log_file_path = os.path.join(
             tempdir, f"{log_prefix}_{utils.logger._get_log_filename()}"
-        )
-        log_file_path_extended = os.path.join(
-            log_file_path, utils.logger._get_log_filename()
         )
 
     # clears old dir
     if os.path.exists(log_file_path):
         os.remove(log_file_path)
-    if os.path.exists(log_file_path_extended):
-        os.remove(log_file_path_extended)
+    if os.path.exists(log_file_path):
+        os.remove(log_file_path)
 
     my_client = utils.client.create(**CONFIG["my_other_instance"])
     utils.logger.enable_toolbox_logging(
@@ -93,6 +90,6 @@ def test_get_with_connection_retry():
             my_client, "/api/service/health", timeout_seconds=10, sleep_seconds=1
         )
 
-    with open(log_file_path_extended, "r") as f:
+    with open(log_file_path, "r") as f:
         # confirm that the intended warning was written to the log
         assert "Caught exception in connect" in f.read()

--- a/tests/utils/test_client.py
+++ b/tests/utils/test_client.py
@@ -66,6 +66,9 @@ def test_get_with_connection_retry():
     with tempfile.TemporaryDirectory() as tempdir:
         log_file_path = os.path.join(tempdir, f"{log_prefix}_{utils.logger._get_log_filename()}")
 
+        if os.path.exists(log_file_path):
+            os.remove(log_file_path)
+
         my_client = utils.client.create(**CONFIG["my_other_instance"])
         utils.logger.enable_toolbox_logging(
             log_to_terminal=False, log_directory=tempdir, log_prefix=log_prefix

--- a/tests/utils/test_client.py
+++ b/tests/utils/test_client.py
@@ -77,12 +77,10 @@ def test_get_with_connection_retry():
     # clears old dir
     if os.path.exists(log_file_path):
         os.remove(log_file_path)
-    if os.path.exists(log_file_path):
-        os.remove(log_file_path)
 
     my_client = utils.client.create(**CONFIG["my_other_instance"])
     utils.logger.enable_toolbox_logging(
-        log_to_terminal=False, log_directory=log_file_path
+        log_to_terminal=False, log_directory=tempdir, log_prefix=log_prefix
     )
 
     with pytest.raises(TimeoutError):

--- a/tests/utils/test_client.py
+++ b/tests/utils/test_client.py
@@ -54,3 +54,13 @@ def test_client_enforce_healthy():
     assert my_client.protocol == CONFIG["my_instance_name"]["protocol"]
     assert my_client.base_path == "/api/versioned/v1/"
     assert my_client.auth == UsernamePasswordAuth("admin", os.environ["TAMR_TOOLBOX_PASSWORD"],)
+
+
+@mock_api()
+def test_get_with_connection_retry():
+    # To ensure timeout error is raised to test correct ConnectionError is caught
+    my_client = utils.client.create(**CONFIG["my_other_instance"])
+    with pytest.raises(TimeoutError):
+        utils.client.get_with_connection_retry(
+            my_client, "/api/service/health", timeout_seconds=10, sleep_seconds=1
+        )


### PR DESCRIPTION

# ↪️ Pull Request
Changed exeption in get_with_connection_error function from python ConnectionError to requests.exception.ConnetionError


## ✔️ PR Todo

- [ ] Add documentation
- [ ] Add examples
- [x] Ensure you are following the practices in the [contributor guide](https://docs.google.com/document/d/1c_hhpDMhO0zN793Z_HFOz42Q4g7l1nPRVQ5pXOUsMJU/edit) and [coding_standards](https://datatamr.atlassian.net/wiki/spaces/FEKB/blog/2020/04/14/1137606830/Customer+Success+Coding+Standards)
  * [Use consistent and descriptive name conventions](https://docs.google.com/document/d/1c_hhpDMhO0zN793Z_HFOz42Q4g7l1nPRVQ5pXOUsMJU/edit#heading=h.477s36w4rds9) 
  * [Uses google-style docstrings](https://datatamr.atlassian.net/wiki/spaces/FEKB/blog/2020/04/14/1137606830/Customer+Success+Coding+Standards#Google-style-docstrings)
  * [Uses versioned API/client methods only](https://docs.google.com/document/d/1c_hhpDMhO0zN793Z_HFOz42Q4g7l1nPRVQ5pXOUsMJU/edit#heading=h.yv6df99fyrq2)
  * [Avoid global variables](https://datatamr.atlassian.net/wiki/spaces/FEKB/blog/2020/04/14/1137606830/Customer+Success+Coding+Standards#Avoid-global-variables)
  * [Avoid giant try/catch](https://datatamr.atlassian.net/wiki/spaces/FEKB/blog/2020/04/14/1137606830/Customer+Success+Coding+Standards#Avoid-giant-try-/-except)
  * [Don't use mutable default variables](https://datatamr.atlassian.net/wiki/spaces/FEKB/blog/2020/04/14/1137606830/Customer+Success+Coding+Standards#Don%E2%80%99t-use-mutable-default-arguments)
  * [Use a `main()` function in your scripts](https://datatamr.atlassian.net/wiki/spaces/FEKB/blog/2020/04/14/1137606830/Customer+Success+Coding+Standards#Use-a-%E2%80%9Cmain()%E2%80%9D--function-in-your-scripts)
- [x] Added/updated testing for this change (ensure you are testing any changes/new code!)
- [x] Update title to link to TBOX issue (i.e. start pull request title with TBOX-xx) 
- [x] Approval from first code-reviewer
- [x] Approval from second code-reviewer (only required if a second reviewer has left comments)
- [x] Pass all checks
