### PR TITLE
TBOX-217-remove repeated lines

### DIFF
--- a/examples/snippets/workflow/run_backup_restore.py
+++ b/examples/snippets/workflow/run_backup_restore.py
@@ -15,10 +15,6 @@ for tamr_backup in backups:
 LOGGER.info("Deleting old sparkEventLogs")
 tbox.workflow.backup.delete_old_spark_event_logs("/home/ubuntu", num_days_to_keep=14)
 
-# optional: delete old sparkEventLogs before backup to reduce backup size
-LOGGER.info("Deleting old sparkEventLogs")
-tbox.workflow.backup.delete_old_spark_event_logs("/home/ubuntu", num_days_to_keep=14)
-
 LOGGER.info("About to run backup")
 op = tbox.workflow.backup.initiate_backup(tamr)
 backup_id = op.json()["relativeId"]


### PR DESCRIPTION
TBOX-217
In tamr-toolbox/run_backup_restore.py, lines 14-16 were repeated in lines 17-19. Lines 17-19 have been removed.

<!---
Thanks for filing a pull request 😄 ! 

Pull requests are only accepted from Tamr employees. If there is a change you would like to see, please file a GitHub Issue or contact your Tamr Professional Services representative.

Below is a checklist of things to do before it can be merged.
-->

# ↪️ Pull Request

<!---
TBOX-217: Remove repeated line in examples/snippets/workflow/run_backup_restore.py

In run_backup_restore.py lines 14-16 are repeated in lines 17-19: tamr-toolbox/run_backup_restore.py at b5763832a8c7f9f6240a66dbee320c4f45ebcbd6 · Datatamer/tamr-toolbox 

This causes the code shown in github.io to also repeat at https://datatamer.github.io/tamr-toolbox/latest/examples/workflow.html#run-backup-restore
-->


## ✔️ PR Todo

- [x] ~Add documentation~
- [x] ~Add examples~
- [x] Ensure you are following the practices in the [contributor guide](https://docs.google.com/document/d/1c_hhpDMhO0zN793Z_HFOz42Q4g7l1nPRVQ5pXOUsMJU/edit) and [coding_standards](https://datatamr.atlassian.net/wiki/spaces/FEKB/blog/2020/04/14/1137606830/Customer+Success+Coding+Standards)
  * [Use consistent and descriptive name conventions](https://docs.google.com/document/d/1c_hhpDMhO0zN793Z_HFOz42Q4g7l1nPRVQ5pXOUsMJU/edit#heading=h.477s36w4rds9) 
  * [Uses google-style docstrings](https://datatamr.atlassian.net/wiki/spaces/FEKB/blog/2020/04/14/1137606830/Customer+Success+Coding+Standards#Google-style-docstrings)
  * [Uses versioned API/client methods only](https://docs.google.com/document/d/1c_hhpDMhO0zN793Z_HFOz42Q4g7l1nPRVQ5pXOUsMJU/edit#heading=h.yv6df99fyrq2)
  * [Avoid global variables](https://datatamr.atlassian.net/wiki/spaces/FEKB/blog/2020/04/14/1137606830/Customer+Success+Coding+Standards#Avoid-global-variables)
  * [Avoid giant try/catch](https://datatamr.atlassian.net/wiki/spaces/FEKB/blog/2020/04/14/1137606830/Customer+Success+Coding+Standards#Avoid-giant-try-/-except)
  * [Don't use mutable default variables](https://datatamr.atlassian.net/wiki/spaces/FEKB/blog/2020/04/14/1137606830/Customer+Success+Coding+Standards#Don%E2%80%99t-use-mutable-default-arguments)
  * [Use a `main()` function in your scripts](https://datatamr.atlassian.net/wiki/spaces/FEKB/blog/2020/04/14/1137606830/Customer+Success+Coding+Standards#Use-a-%E2%80%9Cmain()%E2%80%9D--function-in-your-scripts)
- [x] ~Added/updated testing for this change (ensure you are testing any changes/new code!)~
- [x] Update title to link to TBOX issue (i.e. start pull request title with TBOX-xx) 
- [x] Approval from first code-reviewer
- [ ] ~Approval from second code-reviewer (only required if a second reviewer has left comments)~
- [x] Pass all checks
