### PR TITLE
TBOX-225-documentation-duplicated-code-in-backup-and-restore-example

### DIFF
--- a/docs/latest/examples/workflow.html
+++ b/docs/latest/examples/workflow.html
@@ -195,11 +195,7 @@
 <span class="n">backups</span> <span class="o">=</span> <span class="n">tbox</span><span class="o">.</span><span class="n">workflow</span><span class="o">.</span><span class="n">backup</span><span class="o">.</span><span class="n">list_backups</span><span class="p">(</span><span class="n">tamr</span><span class="p">)</span>
 <span class="k">for</span> <span class="n">tamr_backup</span> <span class="ow">in</span> <span class="n">backups</span><span class="p">:</span>
     <span class="n">LOGGER</span><span class="o">.</span><span class="n">debug</span><span class="p">(</span><span class="n">tamr_backup</span><span class="p">)</span>
-
-<span class="c1"># optional: delete old sparkEventLogs before backup to reduce backup size</span>
-<span class="n">LOGGER</span><span class="o">.</span><span class="n">info</span><span class="p">(</span><span class="s2">&quot;Deleting old sparkEventLogs&quot;</span><span class="p">)</span>
-<span class="n">tbox</span><span class="o">.</span><span class="n">workflow</span><span class="o">.</span><span class="n">backup</span><span class="o">.</span><span class="n">delete_old_spark_event_logs</span><span class="p">(</span><span class="s2">&quot;/home/ubuntu&quot;</span><span class="p">,</span> <span class="n">num_days_to_keep</span><span class="o">=</span><span class="mi">14</span><span class="p">)</span>
-
+    
 <span class="c1"># optional: delete old sparkEventLogs before backup to reduce backup size</span>
 <span class="n">LOGGER</span><span class="o">.</span><span class="n">info</span><span class="p">(</span><span class="s2">&quot;Deleting old sparkEventLogs&quot;</span><span class="p">)</span>
 <span class="n">tbox</span><span class="o">.</span><span class="n">workflow</span><span class="o">.</span><span class="n">backup</span><span class="o">.</span><span class="n">delete_old_spark_event_logs</span><span class="p">(</span><span class="s2">&quot;/home/ubuntu&quot;</span><span class="p">,</span> <span class="n">num_days_to_keep</span><span class="o">=</span><span class="mi">14</span><span class="p">)</span>


### PR DESCRIPTION
deleted duplicated code snippet for deleting old sparkEventLogs in the Run Backup Restore example

# ↪️ Pull Request

The Run Backup Restore example had the following section twice:

# optional: delete old sparkEventLogs before backup to reduce backup size
LOGGER.info("Deleting old sparkEventLogs")
tbox.workflow.backup.delete_old_spark_event_logs("/home/ubuntu", num_days_to_keep=14)

So I removed one of them.

## ✔️ PR Todo

- [x] Add documentation
- [x] Update title to link to TBOX issue (i.e. start pull request title with TBOX-xx) 
- [x] Approval from first code-reviewer
- [x] Approval from second code-reviewer (only required if a second reviewer has left comments)
- [x] Pass all checks
