### PR TITLE
TBOX 295 Extend df-connect Client to have an optional certfile

### DIFF
--- a/tests/data_io/test_connect.py
+++ b/tests/data_io/test_connect.py
@@ -5,6 +5,9 @@ from tamr_toolbox.utils.config import from_yaml
 from tests._common import get_toolbox_root_dir
 
 CONFIG = from_yaml(get_toolbox_root_dir() / "tests/mocking/resources/connect.config.yaml")
+CONFIG_WITH_CERT = from_yaml(
+    get_toolbox_root_dir() / "tests/mocking/resources/connect.certified_config.yaml"
+)
 CONFIG_HTTPS = from_yaml(
     get_toolbox_root_dir() / "tests/mocking/resources/connect_https.config.yaml"
 )
@@ -37,6 +40,22 @@ def test_create_with_multiple_parameters(protocol: str, port: str, base_path: st
         jdbc_dict=CONFIG["df_connect"]["jdbc"]["ingest"],
     )
     assert expected == client._get_url(connect_info, "api/jdbc/ingest")
+
+
+def test_create_with_certfile():
+    connect_info = client.create(
+        host="localhost",
+        port="9030",
+        protocol="http",
+        tamr_username="",
+        tamr_password="",
+        base_path="",
+        jdbc_dict=CONFIG["df_connect"]["jdbc"]["ingest"],
+        cert="pretend_cert",
+    )
+    assert "http://localhost:9030/api/jdbc/ingest" == client._get_url(
+        connect_info, "api/jdbc/ingest"
+    )
 
 
 def test_create_bad_configuration():
@@ -93,6 +112,17 @@ def test_deployment_parsing():
     assert my_connect.base_path == ""
     assert my_connect.tamr_username == "my_user"
     assert my_connect.tamr_password == "my_password"
+
+
+def test_certfile_parsing():
+    my_connect = client.from_config(CONFIG_WITH_CERT)
+    assert my_connect.host == "localhost"
+    assert my_connect.port == "9030"
+    assert my_connect.protocol == "http"
+    assert my_connect.base_path == ""
+    assert my_connect.tamr_username == "my_user"
+    assert my_connect.tamr_password == "my_password"
+    assert my_connect.cert == "path_to_my_cert"
 
 
 def test_jdbc_parsing():

--- a/tests/mocking/resources/connect.certified_config.yaml
+++ b/tests/mocking/resources/connect.certified_config.yaml
@@ -1,0 +1,13 @@
+df_connect:
+    host: localhost
+    protocol: "http"
+    port: "9030"
+    tamr_username: my_user
+    tamr_password: my_password
+    cert: "path_to_my_cert"
+    jdbc:
+        ingest:
+            jdbc_url: tamr::jdbc_ingest
+            db_user: ingest_user
+            db_password: ingest_pw
+            fetch_size: 10000


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! 

Pull requests are only accepted from Tamr employees. If there is a change you would like to see, please file a GitHub Issue or contact your Tamr Professional Services representative.

Below is a checklist of things to do before it can be merged.
-->

# ↪️ Pull Request

<!---
Currently, functions related to df connect go through a “secondary client” (instead of inheriting from the standard client class)

[tamr-toolbox/client.py at master · Datatamer/tamr-toolbox](https://github.com/Datatamer/tamr-toolbox/blob/master/tamr_toolbox/data_io/df_connect/client.py#L187)


One oversight is that there is no way for a customer to use a certfile for auth.

Proposed fix would be to extend df_connect.client.Client() to have an inputtable auth file
-->


## ✔️ PR Todo

- [x] Add documentation
- [ ] Add examples
- [x] Ensure you are following the practices in the [contributor guide](https://docs.google.com/document/d/1c_hhpDMhO0zN793Z_HFOz42Q4g7l1nPRVQ5pXOUsMJU/edit) and [coding_standards](https://datatamr.atlassian.net/wiki/spaces/FEKB/blog/2020/04/14/1137606830/Customer+Success+Coding+Standards)
  * [Use consistent and descriptive name conventions](https://docs.google.com/document/d/1c_hhpDMhO0zN793Z_HFOz42Q4g7l1nPRVQ5pXOUsMJU/edit#heading=h.477s36w4rds9) 
  * [Uses google-style docstrings](https://datatamr.atlassian.net/wiki/spaces/FEKB/blog/2020/04/14/1137606830/Customer+Success+Coding+Standards#Google-style-docstrings)
  * [Uses versioned API/client methods only](https://docs.google.com/document/d/1c_hhpDMhO0zN793Z_HFOz42Q4g7l1nPRVQ5pXOUsMJU/edit#heading=h.yv6df99fyrq2)
  * [Avoid global variables](https://datatamr.atlassian.net/wiki/spaces/FEKB/blog/2020/04/14/1137606830/Customer+Success+Coding+Standards#Avoid-global-variables)
  * [Avoid giant try/catch](https://datatamr.atlassian.net/wiki/spaces/FEKB/blog/2020/04/14/1137606830/Customer+Success+Coding+Standards#Avoid-giant-try-/-except)
  * [Don't use mutable default variables](https://datatamr.atlassian.net/wiki/spaces/FEKB/blog/2020/04/14/1137606830/Customer+Success+Coding+Standards#Don%E2%80%99t-use-mutable-default-arguments)
  * [Use a `main()` function in your scripts](https://datatamr.atlassian.net/wiki/spaces/FEKB/blog/2020/04/14/1137606830/Customer+Success+Coding+Standards#Use-a-%E2%80%9Cmain()%E2%80%9D--function-in-your-scripts)
- [x] Added/updated testing for this change (ensure you are testing any changes/new code!)
- [x] Update title to link to TBOX issue (i.e. start pull request title with TBOX-xx) 
- [x] Approval from first code-reviewer
- [ ] Approval from second code-reviewer (only required if a second reviewer has left comments)
- [x] Pass all checks
