### PR TITLE
TBOX-111.1: correction of attribute name format

### DIFF
--- a/tamr_toolbox/data_io/df_connect/client.py
+++ b/tamr_toolbox/data_io/df_connect/client.py
@@ -164,7 +164,7 @@ def _get_export_config(
     multi_value_delimiter: str = "|",
     limit_records: int = 0,
     columns_exclude_regex: str = "",
-    renameFields: Dict[str, str] = {},
+    rename_fields: Dict[str, str] = {},
 ) -> Dict:
     """Packages relevant pieces of JdbcExportInfo object into an exportDataConfig for jdbc export
      in form of json dictionary
@@ -174,7 +174,7 @@ def _get_export_config(
         limit_records: number of records to stream. default is 0 (export all records)
         columns_exclude_regex: override config file for columnsExcludeRegex, default is empty
             string
-        renameFields: Dictionary in the format {“field_to_be_renamed”:“new_name”}
+        rename_fields: Dictionary in the format {“field_to_be_renamed”:“new_name”}
 
     Returns:
         A dictionary suitable for usage in all df_connect API calls around jdbc export
@@ -185,7 +185,7 @@ def _get_export_config(
         "mergedArrayValuesDelimiter": multi_value_delimiter,
         "limitRecords": limit_records,
         "columnsExcludeRegex": columns_exclude_regex,
-        "renameFields": renameFields,
+        "renameFields": rename_fields,
     }
     return export_config
 
@@ -212,7 +212,7 @@ def get_connect_session(connect_info: Client) -> requests.Session:
         An authenticated session
 
     Raises:
-        RuntimeError: if the a connection to df_connect cannot be established
+        RuntimeError: if a connection to df_connect cannot be established
     """
     auth = UsernamePasswordAuth(connect_info.tamr_username, connect_info.tamr_password)
     s = requests.Session()


### PR DESCRIPTION
# ↪️ Pull Request

Missed a format issue on the PR for TBOX-111. Corrected this and an additional typo in the same file


## ✔️ PR Todo

- [ ] Add documentation
- [ ] Add examples
- [ ] Ensure you are following the practices in the [contributor guide](https://docs.google.com/document/d/1c_hhpDMhO0zN793Z_HFOz42Q4g7l1nPRVQ5pXOUsMJU/edit) and [coding_standards](https://datatamr.atlassian.net/wiki/spaces/FEKB/blog/2020/04/14/1137606830/Customer+Success+Coding+Standards)
  * [Use consistent and descriptive name conventions](https://docs.google.com/document/d/1c_hhpDMhO0zN793Z_HFOz42Q4g7l1nPRVQ5pXOUsMJU/edit#heading=h.477s36w4rds9) 
  * [Uses google-style docstrings](https://datatamr.atlassian.net/wiki/spaces/FEKB/blog/2020/04/14/1137606830/Customer+Success+Coding+Standards#Google-style-docstrings)
  * [Uses versioned API/client methods only](https://docs.google.com/document/d/1c_hhpDMhO0zN793Z_HFOz42Q4g7l1nPRVQ5pXOUsMJU/edit#heading=h.yv6df99fyrq2)
  * [Avoid global variables](https://datatamr.atlassian.net/wiki/spaces/FEKB/blog/2020/04/14/1137606830/Customer+Success+Coding+Standards#Avoid-global-variables)
  * [Avoid giant try/catch](https://datatamr.atlassian.net/wiki/spaces/FEKB/blog/2020/04/14/1137606830/Customer+Success+Coding+Standards#Avoid-giant-try-/-except)
  * [Don't use mutable default variables](https://datatamr.atlassian.net/wiki/spaces/FEKB/blog/2020/04/14/1137606830/Customer+Success+Coding+Standards#Don%E2%80%99t-use-mutable-default-arguments)
  * [Use a `main()` function in your scripts](https://datatamr.atlassian.net/wiki/spaces/FEKB/blog/2020/04/14/1137606830/Customer+Success+Coding+Standards#Use-a-%E2%80%9Cmain()%E2%80%9D--function-in-your-scripts)
- [ ] Added/updated testing for this change (ensure you are testing any changes/new code!)
- [ ] Update title to link to TBOX issue (i.e. start pull request title with TBOX-xx) 
- [ ] Approval from first code-reviewer
- [ ] Approval from second code-reviewer (only required if a second reviewer has left comments)
- [ ] Pass all checks
