### PR TITLE
TBOX-264: Build docs once during CI instead of with every Python version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  Lint:
+  Lint-And-Build-Docs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -30,6 +30,8 @@ jobs:
       run: invoke lint
     - name: Run black
       run: invoke format
+    - name: Run docs
+      run: invoke docs
   Test:
     strategy:
       matrix:
@@ -45,8 +47,6 @@ jobs:
         run: python install.py
       - name: Run tests
         run: invoke test
-      - name: Run docs
-        run: invoke docs
   Test-Minimum-Versions:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  Lint-And-Build-Docs:
+  Lint:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -129,7 +129,7 @@ jobs:
           exit 1
   Notify:
     needs:  # List of all preceding jobs
-      - Lint-And-Build-Docs
+      - Lint
       - Test
       - Test-Minimum-Versions
       - Test-Windows

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,7 @@ jobs:
           exit 1
   Notify:
     needs:  # List of all preceding jobs
-      - Lint
+      - Lint-And-Build-Docs
       - Test
       - Test-Minimum-Versions
       - Test-Windows

--- a/tamr_toolbox/enrichment/api_client/google_address_validate.py
+++ b/tamr_toolbox/enrichment/api_client/google_address_validate.py
@@ -27,7 +27,7 @@ def get_maps_client(googlemaps_api_key: str) -> "googlemaps.Client":
         googlemaps_api_key: API key for the Google Maps address validation API
 
     Returns:
-        API client linekd to specified key
+        API client linked to specified key
     """
     import googlemaps
 
@@ -99,7 +99,9 @@ def validate(
     json_resp = json_resp["result"]
 
     # Get USPS address components
-    usps_address: JsonDict = json_resp.get("uspsData", dict()).get("standardizedAddress", dict())
+    usps_address: JsonDict = json_resp.get("uspsData", dict()).get(
+        "standardizedAddress", dict()
+    )
     usps_zipcode = usps_address.get("zipCode")
     if usps_zipcode and usps_address.get("zipCodeExtension"):
         usps_zipcode += "-" + usps_address.get("zipCodeExtension")
@@ -121,8 +123,12 @@ def validate(
         usps_city=usps_address.get("city"),
         usps_state=usps_address.get("state"),
         usps_zip_code=usps_zipcode,
-        latitude=json_resp.get("geocode", dict()).get("location", dict()).get("latitude"),
-        longitude=json_resp.get("geocode", dict()).get("location", dict()).get("longitude"),
+        latitude=json_resp.get("geocode", dict())
+        .get("location", dict())
+        .get("latitude"),
+        longitude=json_resp.get("geocode", dict())
+        .get("location", dict())
+        .get("longitude"),
         place_id=json_resp.get("geocode", dict()).get("placeId"),
         input_granularity=json_resp.get("verdict", dict()).get(
             "inputGranularity", "GRANULARITY_UNSPECIFIED"
@@ -133,9 +139,15 @@ def validate(
         geocode_granularity=json_resp.get("verdict", dict()).get(
             "geocodeGranularity", "GRANULARITY_UNSPECIFIED"
         ),
-        has_inferred=json_resp.get("verdict", dict()).get("hasInferredComponents", False),
-        has_unconfirmed=json_resp.get("verdict", dict()).get("hasUnconfirmedComponents", False),
-        has_replaced=json_resp.get("verdict", dict()).get("hasReplacedComponents", False),
+        has_inferred=json_resp.get("verdict", dict()).get(
+            "hasInferredComponents", False
+        ),
+        has_unconfirmed=json_resp.get("verdict", dict()).get(
+            "hasUnconfirmedComponents", False
+        ),
+        has_replaced=json_resp.get("verdict", dict()).get(
+            "hasReplacedComponents", False
+        ),
         address_complete=json_resp.get("verdict", dict()).get("addressComplete", False),
     )
 

--- a/tamr_toolbox/enrichment/api_client/google_address_validate.py
+++ b/tamr_toolbox/enrichment/api_client/google_address_validate.py
@@ -99,9 +99,7 @@ def validate(
     json_resp = json_resp["result"]
 
     # Get USPS address components
-    usps_address: JsonDict = json_resp.get("uspsData", dict()).get(
-        "standardizedAddress", dict()
-    )
+    usps_address: JsonDict = json_resp.get("uspsData", dict()).get("standardizedAddress", dict())
     usps_zipcode = usps_address.get("zipCode")
     if usps_zipcode and usps_address.get("zipCodeExtension"):
         usps_zipcode += "-" + usps_address.get("zipCodeExtension")
@@ -123,12 +121,8 @@ def validate(
         usps_city=usps_address.get("city"),
         usps_state=usps_address.get("state"),
         usps_zip_code=usps_zipcode,
-        latitude=json_resp.get("geocode", dict())
-        .get("location", dict())
-        .get("latitude"),
-        longitude=json_resp.get("geocode", dict())
-        .get("location", dict())
-        .get("longitude"),
+        latitude=json_resp.get("geocode", dict()).get("location", dict()).get("latitude"),
+        longitude=json_resp.get("geocode", dict()).get("location", dict()).get("longitude"),
         place_id=json_resp.get("geocode", dict()).get("placeId"),
         input_granularity=json_resp.get("verdict", dict()).get(
             "inputGranularity", "GRANULARITY_UNSPECIFIED"
@@ -139,15 +133,9 @@ def validate(
         geocode_granularity=json_resp.get("verdict", dict()).get(
             "geocodeGranularity", "GRANULARITY_UNSPECIFIED"
         ),
-        has_inferred=json_resp.get("verdict", dict()).get(
-            "hasInferredComponents", False
-        ),
-        has_unconfirmed=json_resp.get("verdict", dict()).get(
-            "hasUnconfirmedComponents", False
-        ),
-        has_replaced=json_resp.get("verdict", dict()).get(
-            "hasReplacedComponents", False
-        ),
+        has_inferred=json_resp.get("verdict", dict()).get("hasInferredComponents", False),
+        has_unconfirmed=json_resp.get("verdict", dict()).get("hasUnconfirmedComponents", False),
+        has_replaced=json_resp.get("verdict", dict()).get("hasReplacedComponents", False),
         address_complete=json_resp.get("verdict", dict()).get("addressComplete", False),
     )
 


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! 

Pull requests are only accepted from Tamr employees. If there is a change you would like to see, please file a GitHub Issue or contact your Tamr Professional Services representative.

Below is a checklist of things to do before it can be merged.
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->
This moves the docs build earlier in the CI, so failures are visible sooner and the docs are only built with the version we use to build release docs. Note that the `Test` and following steps will still run if the `Lint` step fails. 

## ✔️ PR Todo

- [X] Add documentation
- [ ] Add examples
- [X] Ensure you are following the practices in the [contributor guide](https://docs.google.com/document/d/1c_hhpDMhO0zN793Z_HFOz42Q4g7l1nPRVQ5pXOUsMJU/edit) and [coding_standards](https://datatamr.atlassian.net/wiki/spaces/FEKB/blog/2020/04/14/1137606830/Customer+Success+Coding+Standards)
  * [Use consistent and descriptive name conventions](https://docs.google.com/document/d/1c_hhpDMhO0zN793Z_HFOz42Q4g7l1nPRVQ5pXOUsMJU/edit#heading=h.477s36w4rds9) 
  * [Uses google-style docstrings](https://datatamr.atlassian.net/wiki/spaces/FEKB/blog/2020/04/14/1137606830/Customer+Success+Coding+Standards#Google-style-docstrings)
  * [Uses versioned API/client methods only](https://docs.google.com/document/d/1c_hhpDMhO0zN793Z_HFOz42Q4g7l1nPRVQ5pXOUsMJU/edit#heading=h.yv6df99fyrq2)
  * [Avoid global variables](https://datatamr.atlassian.net/wiki/spaces/FEKB/blog/2020/04/14/1137606830/Customer+Success+Coding+Standards#Avoid-global-variables)
  * [Avoid giant try/catch](https://datatamr.atlassian.net/wiki/spaces/FEKB/blog/2020/04/14/1137606830/Customer+Success+Coding+Standards#Avoid-giant-try-/-except)
  * [Don't use mutable default variables](https://datatamr.atlassian.net/wiki/spaces/FEKB/blog/2020/04/14/1137606830/Customer+Success+Coding+Standards#Don%E2%80%99t-use-mutable-default-arguments)
  * [Use a `main()` function in your scripts](https://datatamr.atlassian.net/wiki/spaces/FEKB/blog/2020/04/14/1137606830/Customer+Success+Coding+Standards#Use-a-%E2%80%9Cmain()%E2%80%9D--function-in-your-scripts)
- [X] Added/updated testing for this change (ensure you are testing any changes/new code!)
- [X] Update title to link to TBOX issue (i.e. start pull request title with TBOX-xx) 
- [ ] Approval from first code-reviewer
- [ ] Approval from second code-reviewer (only required if a second reviewer has left comments)
- [ ] Pass all checks
